### PR TITLE
Fix typo in tree-view shortcut and edit launch command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Run ```apm install atom-shortcuts``` to install the package.
 
-I love shortcuts. I love to be productive. Shortcuts tend to increase developer's productivity by 146%.  To learn Atom's shortcuts I've found [this](http://d2wy8f7a9ursnm.cloudfront.net/atom-editor-cheat-sheet.pdf) cheatsheet and I liked it for the most part, except I had to toggle between Atom and Preview App to go and check for a shortcut needed for a certain action. That's why I wrote this extension. Simply hit **ctrl + `** (`ctrl + backtick`) and you will get a cheatsheet on your screen immediately.
+I love shortcuts. I love to be productive. Shortcuts tend to increase developer's productivity by 146%.  To learn Atom's shortcuts I've found [this](http://d2wy8f7a9ursnm.cloudfront.net/atom-editor-cheat-sheet.pdf) cheatsheet and I liked it for the most part, except I had to toggle between Atom and Preview App to go and check for a shortcut needed for a certain action. That's why I wrote this extension. Simply hit __ctrl + `__ (`ctrl + backtick`) and you will get a cheatsheet on your screen immediately.

--- a/lib/atom-shortcuts.coffee
+++ b/lib/atom-shortcuts.coffee
@@ -87,7 +87,7 @@ module.exports = AtomShortcuts =
       <div class='section'>
         <h2>View/Window Manipulation</h2>
         <div class='item'>
-          <p><b>⌘+ \</b></p>
+          <p><b>⌘+ \\</b></p>
           Toggle tree-view sidebar
         </div>
         <div class='item'>


### PR DESCRIPTION
@olegberman this PR fixes a display bug in the shortcut list, and will close #10  if merged. I also edited the bold text in the README so that the launch command displayed correctly. 