### PR TITLE
fix markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Run ```apm install atom-shortcuts``` to install the package.
 
-I love shortcuts. I love to be productive. Shortcuts tend to increase developer's productivity by 146%.  To learn Atom's shortcuts I've found [this](http://d2wy8f7a9ursnm.cloudfront.net/atom-editor-cheat-sheet.pdf) cheatsheet and I liked it for the most part, except I had to toggle between Atom and Preview App to go and check for a shortcut needed for a certain action. That's why I wrote this extension. Simply hit **ctrl + `** (`ctrl + backtick`) and you will get a cheatsheet on your screen immediately.
+I love shortcuts. I love to be productive. Shortcuts tend to increase developer's productivity by 146%.  To learn Atom's shortcuts I've found [this](http://d2wy8f7a9ursnm.cloudfront.net/atom-editor-cheat-sheet.pdf) cheatsheet and I liked it for the most part, except I had to toggle between Atom and Preview App to go and check for a shortcut needed for a certain action. That's why I wrote this extension. Simply hit **ctrl + \`** (`ctrl + backtick`) and you will get a cheatsheet on your screen immediately.


### PR DESCRIPTION
Escapes the backtick so it's formatted properly.

Current master: https://github.com/olegberman/atom-shortcuts/blob/d29b7199f56cd24dc65f3d157fc87d149b7f7c40/README.md
vs patched version: https://github.com/jetpack/atom-shortcuts/blob/patch-1/README.md